### PR TITLE
Add sequence->stream.

### DIFF
--- a/typed/racket/stream.rkt
+++ b/typed/racket/stream.rkt
@@ -19,3 +19,7 @@
  [stream-append (All (a) [(Sequenceof a) * -> (Sequenceof a)])]
  )
 
+(require/typed/provide
+ racket/base
+ [sequence->stream (All (a) (-> (Sequenceof a) (Sequenceof a)))]
+ )


### PR DESCRIPTION
Add a type for `sequence->stream`.

This function does not technically come from `racket/stream`, but it seems natural to me to have it once I am working with streams.